### PR TITLE
feat(landing) display QG version and git hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "eslint-plugin-vue": "^6.0.1",
+    "git-describe": "^4.0.4",
     "jest": "^24.9.0",
     "markdown-it": "^10.0.0",
     "node-sass": "^4.9.0",

--- a/src/components/HomePage/index.vue
+++ b/src/components/HomePage/index.vue
@@ -4,7 +4,7 @@
       <img src="@/assets/graphics/QG_logo.svg" alt="QuantumGame" />
     </div>
     <router-link to="/level/1">
-      <app-button type="big">PLAY</app-button>
+      <app-button type="big">PLAY (alpha: {{ version }})</app-button>
     </router-link>
     <br />
     <div class="hello">
@@ -17,8 +17,9 @@
         Visit us on
         <a href="https://twitter.com/quantumgameio" target="_blank">Twitter</a>,
         <a href="https://www.facebook.com/quantumgameio/" target="_blank">Facebook</a>,
-        <a href="https://github.com/stared/quantum-game-2" target="_blank">Github</a> and
-        <a href="https://medium.com/quantum-photons" target="_blank">Medium</a>.
+        <a href="https://github.com/stared/quantum-game-2" target="_blank">Github</a>
+        (this release: <a :href="commitPath" target="_blank">{{ commitHash }}</a
+        >) and <a href="https://medium.com/quantum-photons" target="_blank">Medium</a>.
       </h1>
       <p>
         Quantum Game is currently being developed by dr
@@ -50,12 +51,21 @@
 import { Vue, Component } from 'vue-property-decorator'
 import AppButton from '@/components/AppButton.vue'
 
+console.log('env', process.env)
+
 @Component({
   components: {
     AppButton
   }
 })
-export default class HomePage extends Vue {}
+export default class HomePage extends Vue {
+  version: string = process.env.VUE_APP_VERSION
+  commitHash: string = process.env.VUE_APP_GIT_HASH
+
+  get commitPath(): string {
+    return `https://github.com/Quantum-Game/quantum-game-2/commit/${this.commitHash}`
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/store/router/index.ts
+++ b/src/store/router/index.ts
@@ -1,0 +1,87 @@
+import Vue from 'vue'
+import Router from 'vue-router'
+
+Vue.use(Router)
+/* eslint-disable */
+export default new Router({
+  mode: 'history',
+  base: process.env.BASE_URL,
+  routes: [
+    {
+      path: '/',
+      name: 'menu',
+      component: () => import('@/components/HomePage/index.vue')
+    },
+    {
+      path: '/levels',
+      name: 'levels',
+      component: () => import('@/components/LevelMapPage/index.vue')
+    },
+    {
+      path: '/levels/shared/:id/:levelsaved',
+      name: 'sharedlevels',
+      component: () => import('@/components/GamePage/index.vue')
+    },
+    {
+      path: '/level/:id',
+      name: 'level',
+      component: () => import('@/components/GamePage/index.vue')
+    },
+    {
+      path: '/level/:id/:levelsaved',
+      name: 'levelsaved',
+      component: () => import('@/components/GamePage/index.vue'),
+      meta: { levelSaved: true }
+    },
+    {
+      path: '/sandbox',
+      name: 'sandbox',
+      component: () => import('@/components/GamePage/index.vue')
+    },
+    {
+      path: '/info',
+      component: () => import('@/components/EncyclopediaPage/index.vue'),
+      children: [
+        {
+          path: '',
+          component: () => import('@/components/EncyclopediaPage/EncyclopediaDefaultArticle.vue')
+        },
+        {
+          path: '/info/:entry',
+          component: () => import('@/components/EncyclopediaPage/EncyclopediaArticle.vue')
+        }
+      ]
+    },
+    {
+      path: '/register',
+      name: 'register',
+      component: () => import('@/components/RegisterPage/index.vue')
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('@/components/LoginPage/index.vue')
+    },
+    {
+      path: '/myaccount',
+      name: 'myaccount',
+      component: () => import('@/components/MyAccountPage/index.vue')
+    },
+    {
+      path: '/savedlevels',
+      name: 'savedlevels',
+      component: () => import('@/components/SavedLevelsPage/index.vue')
+    },
+    {
+      path: '/options',
+      name: 'options',
+      component: () => import('@/components/OptionsPage/index.vue')
+    },
+    {
+      path: '*',
+      name: '404',
+      component: () => import('@/components/NotFoundPage/index.vue')
+    }
+  ]
+})
+/* eslint-enable */

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,4 @@
+const {gitDescribe, gitDescribeSync} = require('git-describe');
+
+process.env.VUE_APP_VERSION = require('./package.json').version
+process.env.VUE_APP_GIT_HASH = gitDescribeSync().hash

--- a/yarn.lock
+++ b/yarn.lock
@@ -5488,6 +5488,15 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-describe@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/git-describe/-/git-describe-4.0.4.tgz#f3d55bce309becf6dc27fed535d380a621967e8c"
+  integrity sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==
+  dependencies:
+    lodash "^4.17.11"
+  optionalDependencies:
+    semver "^5.6.0"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"


### PR DESCRIPTION
I want to make it easier to see which version we display. Right now it works that way:

![image](https://user-images.githubusercontent.com/1001610/73207445-01627500-4145-11ea-9023-1a6f582a66a0.png)

Looking at how to add the release date, as it may be more informative than version (or hash).

@KlemKlem - obviously style is temporary, so feel invited to change it in any way you like.

I didn't try to deploy it yet. Since these are build-related things, it make work or not.

## Notes

It took me quite a lot of time to figure out how to include hash commits. In the end, I use [git-describe](https://www.npmjs.com/package/git-describe), see `vue.config.js`.

I did try:

### [git-revision-webpack-plugin](https://www.npmjs.com/package/git-revision-webpack-plugin) 

Works, but code *seems* extraneous.
`vue.config.js` would look like (example from: https://forum.vuejs.org/t/trying-to-add-gitrevisionplugin-to-cli-3/65567):

    const GitRevisionPlugin = require('git-revision-webpack-plugin')

    module.exports = {
      'chainWebpack': config => {
        config.plugin('define').tap(args => {
          const gitRevisionPlugin = new GitRevisionPlugin()
          args[0]['process.env']['VUE_APP_COMMIT_HASH'] = JSON.stringify(gitRevisionPlugin.commithash())
          return args
        })
      }
    }

### [vue-cli-plugin-git-describe](https://www.npmjs.com/package/vue-cli-plugin-git-describe)

Package not maintained (only a single release) + variables in the global space (problems with linters).

### `.env` or `assets`

`git log -n 1 --pretty=format:"VUE_APP_GIT_HASH=%h%nVUE_APP_GIT_DATE=%aD" >> .env `

But had some issues with reading `.env` variables. Similarly, one can create a JSON asset and load it from there. It might be a not that bad idea (just one need to add extra scripts in `package.json` so to generate these files, always when building).

* https://cli.vuejs.org/guide/mode-and-env.html 
* https://stackoverflow.com/questions/53962583/how-to-add-git-hash-to-vue-js-component
* https://stackoverflow.com/questions/4600445/git-log-output-to-xml-json-or-yaml

### See also:

* https://stackoverflow.com/questions/38400314/including-git-commit-hash-and-date-in-webpack-build
* https://stackoverflow.com/questions/34518389/get-hash-of-most-recent-git-commit-in-node