### PR TITLE
Fix rotate on board - and level 2

### DIFF
--- a/src/assets/data/levels/classicLevels.json
+++ b/src/assets/data/levels/classicLevels.json
@@ -140,6 +140,17 @@
           "frozen": true,
           "active": false,
           "energized": false
+        },
+        {
+          "coord": {
+            "y": 8,
+            "x": 9
+          },
+          "element": "Rock",
+          "rotation": 0,
+          "frozen": true,
+          "active": false,
+          "energized": false
         }
       ]
     },

--- a/src/assets/data/levels/classicLevels.json
+++ b/src/assets/data/levels/classicLevels.json
@@ -164,7 +164,7 @@
         "threshold": 1
       }
     ],
-    "tools": ["Rock"]
+    "tools": []
   },
 
   {

--- a/src/components/Board/AppCell.vue
+++ b/src/components/Board/AppCell.vue
@@ -107,7 +107,7 @@ const borderColors = {
 export default class AppCell extends Mixins(Position) {
   @Prop() readonly cell!: Cell
   @Prop() readonly tileSize!: number
-  @Prop({ default: true }) readonly available!: boolean
+  @Prop({ default: true }) readonly available!: boolean // looks like this is NOT needed
   @Mutation('SET_ACTIVE_CELL') mutationSetActiveCell!: (cell: Cell) => void
   @Mutation('RESET_ACTIVE_CELL') mutationResetActiveCell!: () => void
   @Mutation('SET_HOVERED_CELL') mutationSetHoveredCell!: (cell: Cell) => void
@@ -212,6 +212,9 @@ export default class AppCell extends Mixins(Position) {
     window.removeEventListener('mouseup', this.dragEnd)
   }
 
+  /**
+   * This below is a monstrosity
+   */
   handleCellClick(): void {
     // START SIMULATION: Drilling to Game
     if (this.cell.isLaser && this.cell.frozen) {
@@ -228,7 +231,7 @@ export default class AppCell extends Mixins(Position) {
       this.mutationResetActiveCell()
     } else {
       // ROTATE CELL
-      if (this.isActiveCell && this.cell.isFromGrid && this.isRotate) {
+      if (this.isActiveCell && !this.cell.isFromGrid && this.isRotate) {
         this.cell.rotate()
         this.isRotate = false
       }
@@ -292,6 +295,7 @@ export default class AppCell extends Mixins(Position) {
 
   /**
    * Computed class
+   * A fcking monstrosity
    */
   get computeCellClass(): string[] {
     return [

--- a/src/engine/Cell.ts
+++ b/src/engine/Cell.ts
@@ -51,7 +51,7 @@ export default class Cell {
     frozen = false,
     active = false,
     energized = false,
-    tool = false
+    tool = true // dangerous, interferes with frozen
   ) {
     // super(coord.y, coord.x)
     this.coord = coord
@@ -215,7 +215,8 @@ export default class Cell {
       iCell.percentage,
       iCell.frozen,
       iCell.active,
-      iCell.energized
+      iCell.energized,
+      !iCell.frozen
     )
     return cell
   }


### PR DESCRIPTION
To start with - a lot of things with cell is seriously fu- I mean, can and should be abstracted better. As of now, it was not possible to load a non-frozen element on board.

In general, there should be no redundancy - as it is error-prone (and very bad style).

![image](https://user-images.githubusercontent.com/1001610/78314328-f61f3180-7559-11ea-99c8-680da6a55981.png)
