### PR TITLE
Level sharing clean-up

### DIFF
--- a/src/components/GamePage/index.vue
+++ b/src/components/GamePage/index.vue
@@ -230,7 +230,7 @@ export default class Game extends Vue {
     if (this.isCustomLevel) {
       // 1) dispatch action for vuex to get the level, the "shared" parameter
       //    handles which db we target
-      this.actionGetLevelStoreData({ id: this.levelId, shared: this.$route.meta.shared })
+      this.actionGetLevelStoreData({ id: this.levelId })
         .then(() => {
           // 2) subscribe to mutation triggered asynchronously
           this.unsubscribe = this.$store.subscribe((mutation, rootState) => {

--- a/src/components/MyAccountPage/index.vue
+++ b/src/components/MyAccountPage/index.vue
@@ -2,26 +2,10 @@
   <app-layout>
     <div slot="main">
       <h1>My Account</h1>
-      <h2>Hello {{ moduleGetterUserName }}</h2>
-      <div>
-        <label>Status: </label>
-        <input v-model="level.status" type="text" />
-        <label> Score: </label>
-        <input v-model="level.score" type="text" />
-      </div>
-      <br />
-      <br />
-      <ul class="levels-progress">
-        <li v-for="(lvl, index) in moduleGettrProgressArr" :key="index">
-          Level: {{ lvl.id }} Status: {{ lvl.status }} Score: {{ lvl.score }}
-          <span class="edit-level" @click="editLevel(lvl)"> >>>> Edit</span>
-        </li>
-      </ul>
-      <a @click.prevent="saveProgressToDB"
-        ><app-button type="special"> Save data to Firestore!!! </app-button></a
-      ><br />
+      <h2>Hi {{ moduleGetterUserName }}!</h2>
+      <p>User page is under construction. Right now, see:</p>
       <router-link to="/savedlevels"
-        ><app-button type="special"> Savedlevels </app-button>
+        ><app-button type="special"> Saved and shared levels </app-button>
       </router-link>
     </div>
     <div slot="right">
@@ -38,12 +22,6 @@ import AppButton from '@/components/AppButton.vue'
 
 const user = namespace('userModule')
 
-interface IAccountLevel {
-  id: number
-  status: ''
-  score: number
-}
-
 @Component({
   components: {
     AppLayout,
@@ -51,34 +29,11 @@ interface IAccountLevel {
   },
 })
 export default class MyAccount extends Vue {
-  @user.Mutation('SET_PROGRESS') mutationSetProgress!: Function
-  @user.Action('SET_INITIAL_PROGRESS') actionSetInitialProgress!: Function
-  @user.Action('SAVE_PROGRESS') actionSaveProgress!: Function
   @user.Action('SIGN_OUT') actionSignOut!: Function
-  @user.Getter('progressArr') moduleGettrProgressArr!: []
   @user.Getter('userName') moduleGetterUserName!: string
-  level = {
-    id: 0,
-    status: '',
-    score: 0,
-  }
-
-  created(): void {
-    this.actionSetInitialProgress()
-  }
 
   signOut(): void {
     this.actionSignOut(this.moduleGetterUserName)
-  }
-
-  saveProgressToDB(): void {
-    console.debug(this.moduleGettrProgressArr)
-    this.mutationSetProgress(this.moduleGettrProgressArr)
-    this.actionSaveProgress()
-  }
-
-  editLevel(lvl: IAccountLevel): void {
-    this.level = lvl
   }
 }
 </script>

--- a/src/components/SavedLevelsPage/index.vue
+++ b/src/components/SavedLevelsPage/index.vue
@@ -3,15 +3,16 @@
     <div slot="main">
       <h1>Saved Levels</h1>
       <div class="my-levels">
-        <h2>My levels:</h2>
+        <h2>My levels</h2>
         <ul class="levels-list">
           <li v-for="(lvl, index) in moduleGetterSavedLevelsList" :key="index">
-            Level: <router-link :to="lvl.link">{{ lvl.link }}</router-link>
+            <router-link :to="lvl.link">{{ lvl.id.slice(0, 8) }}</router-link>
+            ({{ printDate(lvl.createdAt) }})
             <a class="remove-btn" @click.prevent="removeLevel(lvl.id, lvl.public)"
               ><app-button type="special"> X </app-button></a
             >
             <a v-if="!lvl.public" class="private-btn" @click.prevent="makePublic(lvl.id)"
-              ><app-button type="special"> Private </app-button></a
+              ><app-button type="special"> Unlisted </app-button></a
             >
             <a v-if="lvl.public" class="public-btn" @click.prevent="makePrivate(lvl.id)"
               ><app-button type="basic"> Public </app-button></a
@@ -22,10 +23,11 @@
       <br />
       <br />
       <div class="public-levels">
-        <h2>All public levels:</h2>
+        <h2>All public levels</h2>
         <ul class="levels-list">
           <li v-for="(lvl, index) in moduleGetterPublicLevels" :key="index">
-            Level: <router-link :to="lvl.link">{{ lvl.link }}</router-link>
+            <router-link :to="lvl.link">{{ lvl.id.slice(0, 8) }}</router-link>
+            ({{ printDate(lvl.createdAt) }})
           </li>
         </ul>
       </div>
@@ -60,41 +62,31 @@ export default class SavedLevels extends Vue {
   @user.Getter('savedLevelsList') moduleGetterSavedLevelsList!: []
   @user.Getter('publicLevels') moduleGetterPublicLevels!: []
 
-  // get user(): string {
-  //   return $userStore.getters.userName
-  // }
-
-  // // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // get savedLevels(): any {
-  //   return $userStore.getters.savedLevelsList
-  // }
-
-  // // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // get publicLevels(): any {
-  //   return $userStore.getters.publicLevels
-  // }
-
   removeLevel(id: string, isPublic: boolean): void {
     if (isPublic) {
       this.actionMakeLevelPrivate(id)
     }
-    // $userStore.dispatch('REMOVE_LEVEL', id)
     this.actionRemoveLevel(id)
   }
 
   makePublic(id: string): void {
-    // $userStore.dispatch('MAKE_LEVEL_PUBLIC', id)
     this.actionMakeLevelPublic(id)
   }
 
   makePrivate(id: string): void {
-    // $userStore.dispatch('MAKE_LEVEL_PRIVATE', id)
     this.actionMakeLevelPrivate(id)
   }
 
   signOut(): void {
     this.actionSignOut(this.moduleGetterUserName)
-    // $userStore.dispatch('SIGN_OUT', this.moduleGetterUserName)
+  }
+
+  printDate(timestamp: any): string {
+    if (!timestamp) {
+      return ''
+    }
+    const date = timestamp.toDate()
+    return date.toUTCString()
   }
 }
 </script>

--- a/src/engine/interfaces.ts
+++ b/src/engine/interfaces.ts
@@ -1,39 +1,4 @@
 /**
- * USER STATE INTERFACE
- */
-export interface IUserState {
-  user: {
-    loggedIn: boolean
-    rememberMe: boolean
-    data: {
-      displayName: string
-      email: string
-    }
-  }
-  progressArr: IProgressObj[]
-  savedLevelsList: ISavedLevel[]
-  publicLevels: IPublicLevel[]
-  fetchedLevel: null
-  error?: null
-}
-
-interface IProgressObj {
-  id: number
-  status: 'string'
-  score: number
-}
-
-interface ISavedLevel {
-  id: 'string'
-  link: 'string'
-  public: boolean
-}
-
-interface IPublicLevel {
-  link: 'string'
-}
-
-/**
  * PARTICLE INTERFACE
  * Particle interface in primitives
  */

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,7 +18,7 @@ export default new Router({
       component: () => import('@/components/LevelMapPage/index.vue')
     },
     {
-      path: '/levels/shared/:id/',
+      path: '/level/:username/:id/',
       name: 'sharedlevels',
       component: () => import('@/components/GamePage/index.vue'),
       meta: {

--- a/src/store/storeInterfaces.ts
+++ b/src/store/storeInterfaces.ts
@@ -1,0 +1,52 @@
+import firebase from '@/config/firebase'
+
+import { ILevel } from '@/engine/interfaces'
+import GameState from '@/engine/GameState'
+
+/**
+ * @todo Right now really bad, as level does not match the ILevel format
+ */
+export interface ISavedLevel {
+  userId: string
+  level: {
+    currentLevelID: string
+    gameState: GameState
+    boardState: string // JSON.stringify format
+  }
+  public: boolean
+  createdAt: firebase.firestore.Timestamp
+  lastModified: firebase.firestore.Timestamp
+}
+
+export interface IUserState {
+  user: IUser
+  progressArr: IProgressObj[]
+  savedLevelsList: ISavedLevelMetadata[]
+  publicLevels: ISavedLevelMetadata[]
+  fetchedLevel?: ILevel
+  error?: null
+}
+
+export interface IUser {
+  loggedIn: boolean
+  rememberMe: boolean
+  data: {
+    displayName: string
+    email: string
+  }
+}
+
+export interface IProgressObj {
+  id: number
+  status: string
+  timeOpened: firebase.firestore.Timestamp
+  timeWon?: firebase.firestore.Timestamp
+}
+
+export interface ISavedLevelMetadata {
+  id: string
+  link: string
+  createdAt: firebase.firestore.Timestamp
+  lastModified: firebase.firestore.Timestamp
+  public: boolean
+}

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,9 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-
 import { Module } from 'vuex'
-import { IUserState } from '@/engine/interfaces'
+import {
+  IUserState,
+  IUser,
+  IProgressObj,
+  ISavedLevel,
+  ISavedLevelMetadata,
+} from '@/store/storeInterfaces'
+import { ILevel } from '@/engine/interfaces'
 import router from '@/router'
 import firebase, { db, auth } from '@/config/firebase'
 import { IRootState } from '@/types'
@@ -22,76 +25,77 @@ const userModule: Module<IUserState, IRootState> = {
     progressArr: [],
     savedLevelsList: [],
     publicLevels: [],
-    fetchedLevel: null,
+    fetchedLevel: undefined,
   },
   getters: {
-    user(state) {
+    user(state): IUser {
       return state.user
     },
-    userName(state) {
+    userName(state): string {
       return state.user.data.displayName
     },
-    progressArr(state) {
+    progressArr(state): IProgressObj[] {
       return state.progressArr
     },
-    savedLevelsList(state) {
+    savedLevelsList(state): ISavedLevelMetadata[] {
       return state.savedLevelsList
     },
-    publicLevels(state) {
+    publicLevels(state): ISavedLevelMetadata[] {
       return state.publicLevels
     },
-    isLoggedIn(state) {
+    isLoggedIn(state): boolean {
       return state.user.loggedIn
     },
-    fetchedLevelBoardState(state) {
+    fetchedLevelBoardState(state): ILevel | undefined {
       return state.fetchedLevel
     },
   },
   mutations: {
-    SET_LOGGED_IN(state, payload) {
+    SET_LOGGED_IN(state, payload): void {
       state.user.loggedIn = payload
     },
-    SET_REMEMBER_ME(state, payload) {
+    SET_REMEMBER_ME(state, payload): void {
       state.user.rememberMe = payload
     },
-    SET_USER(state, payload) {
+    SET_USER(state, payload): void {
       state.user.data = payload
     },
-    SET_PROGRESS(state, payload) {
+    SET_PROGRESS(state, payload): void {
       state.progressArr = payload
     },
-    SET_SAVED_LEVELS_LIST(state, payload) {
+    SET_SAVED_LEVELS_LIST(state, payload): void {
       state.savedLevelsList = payload
     },
-    SET_PUBLIC_LEVELS(state, payload) {
+    SET_PUBLIC_LEVELS(state, payload): void {
       state.publicLevels = payload
     },
-    SET_PUBLIC(state, payload) {
+    SET_PUBLIC(state, payload): void {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       state.savedLevelsList.find((x) => x.id === payload)!.public = true
     },
-    SET_PRIVATE(state, payload) {
+    SET_PRIVATE(state, payload): void {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       state.savedLevelsList.find((x) => x.id === payload)!.public = false
     },
-    REMOVE_LEVEL(state, payload) {
+    REMOVE_LEVEL(state, payload): void {
       state.savedLevelsList = state.savedLevelsList.filter(function(obj) {
         return obj.id !== payload
       })
     },
-    SET_FETCHED_LEVEL(state, payload) {
+    SET_FETCHED_LEVEL(state, payload: ILevel): void {
       state.fetchedLevel = payload
     },
-    RESET_FETCHED_LEVEL(state) {
-      state.fetchedLevel = null
+    RESET_FETCHED_LEVEL(state): void {
+      state.fetchedLevel = undefined
     },
   },
   actions: {
-    SET_INITIAL_PROGRESS({ commit }) {
+    SET_INITIAL_PROGRESS({ commit }): void {
       commit('SET_PROGRESS', [
-        { id: 1, status: 'solved', score: 150 },
-        { id: 2, status: 'no', score: 100 },
+        { id: 0, status: 'won', timeOpened: firebase.firestore.Timestamp.fromDate(new Date()) },
       ])
     },
-    FETCH_USER({ commit, dispatch }, user) {
+    FETCH_USER({ commit, dispatch }, user): void {
       commit('SET_LOGGED_IN', user !== null)
       if (user) {
         dispatch('GET_PROGRESS')
@@ -106,7 +110,7 @@ const userModule: Module<IUserState, IRootState> = {
         commit('SET_USER', null)
       }
     },
-    SIGN_IN({ commit, getters }, user) {
+    SIGN_IN({ commit, getters }, user): void {
       commit('SET_REMEMBER_ME', user.rememberMe)
 
       let authPersistance = auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL)
@@ -126,19 +130,19 @@ const userModule: Module<IUserState, IRootState> = {
           commit('SET_ERROR', err.message, { root: true })
         })
     },
-    SIGN_IN_GITHUB({ dispatch }) {
+    SIGN_IN_GITHUB({ dispatch }): void {
       const provider = new firebase.auth.GithubAuthProvider()
       dispatch('SIGN_IN_WITH_POPUP', provider)
     },
-    SIGN_IN_FACEBOOK({ dispatch }) {
+    SIGN_IN_FACEBOOK({ dispatch }): void {
       const provider = new firebase.auth.FacebookAuthProvider()
       dispatch('SIGN_IN_WITH_POPUP', provider)
     },
-    SIGN_IN_GOOGLE({ dispatch }) {
+    SIGN_IN_GOOGLE({ dispatch }): void {
       const provider = new firebase.auth.GoogleAuthProvider()
       dispatch('SIGN_IN_WITH_POPUP', provider)
     },
-    SIGN_IN_WITH_POPUP({ commit }, provider) {
+    SIGN_IN_WITH_POPUP({ commit }, provider): void {
       auth
         .signInWithPopup(provider)
         .then(() => {
@@ -148,7 +152,7 @@ const userModule: Module<IUserState, IRootState> = {
           commit('SET_ERROR', err.message, { root: true })
         })
     },
-    SIGN_UP({ commit }, user) {
+    SIGN_UP({ commit }, user): void {
       auth
         .createUserWithEmailAndPassword(user.email, user.password)
         .then((data) => {
@@ -165,7 +169,7 @@ const userModule: Module<IUserState, IRootState> = {
           commit('SET_ERROR', err.message, { root: true })
         })
     },
-    SIGN_OUT({ commit }) {
+    SIGN_OUT({ commit }): void {
       auth.signOut().then(() => {
         commit('SET_LOGGED_IN', false)
         router.replace({
@@ -173,9 +177,9 @@ const userModule: Module<IUserState, IRootState> = {
         })
       })
     },
-    SAVE_PROGRESS({ commit, getters }) {
+    SAVE_PROGRESS({ commit, getters }): void {
       if (auth.currentUser) {
-        const { progressArr } = getters
+        const { progressArr }: { progressArr: IProgressObj } = getters
         const dbRef = db.collection('users').doc(auth.currentUser.uid)
         const data = { uid: auth.currentUser.uid, progress: progressArr }
 
@@ -189,14 +193,17 @@ const userModule: Module<IUserState, IRootState> = {
           })
       }
     },
-    GET_PROGRESS({ commit }) {
+    /**
+     * @todo It should be a database, not a list.
+     */
+    GET_PROGRESS({ commit }): void {
       if (auth.currentUser) {
         const dbRef = db.collection('users').doc(auth.currentUser.uid)
         dbRef
           .get()
           .then((doc) => {
             if (doc.exists) {
-              const { progress }: any = doc.data()
+              const { progress } = doc.data()!
               commit('SET_PROGRESS', progress)
             } else {
               console.debug('No such document!')
@@ -207,10 +214,12 @@ const userModule: Module<IUserState, IRootState> = {
           })
       }
     },
-    SAVE_LEVEL({ commit, dispatch }, level) {
-      // console.log(level)
+    /**
+     * @todo Does not match level structure from levels in JSON.
+     */
+    SAVE_LEVEL({ commit, dispatch }, level: any): void {
       if (auth.currentUser) {
-        const customLevel: any = {
+        const customLevel: ISavedLevel = {
           userId: auth.currentUser.uid,
           level: {
             currentLevelID: level.currentLevelID,
@@ -239,16 +248,15 @@ const userModule: Module<IUserState, IRootState> = {
         console.log('You are not logged in!')
       }
     },
-    UPDATE_LEVEL({ commit }, level) {
+    UPDATE_LEVEL({ commit }, level): void {
       if (auth.currentUser) {
-        const customLevel: any = {
+        const customLevel: Partial<ISavedLevel> = {
           userId: auth.currentUser.uid,
           level: {
             currentLevelID: level.currentLevelID,
             gameState: level.gameState,
             boardState: level.boardState,
           },
-          // created for firestore update test
           lastModified: firebase.firestore.Timestamp.fromDate(new Date()),
         }
         const levelSaved = router.currentRoute.params.id
@@ -262,9 +270,9 @@ const userModule: Module<IUserState, IRootState> = {
         console.log('You are not logged in!')
       }
     },
-    FETCH_MY_LEVELS({ commit }) {
+    FETCH_MY_LEVELS({ commit }): void {
       if (auth.currentUser) {
-        const myLevels: any = []
+        const myLevels: ISavedLevelMetadata[] = []
         const docs = db.collection('levels').where('userId', '==', auth.currentUser.uid)
 
         docs
@@ -290,9 +298,9 @@ const userModule: Module<IUserState, IRootState> = {
         console.log('You are not logged in!')
       }
     },
-    FETCH_PUBLIC_LEVELS({ commit }) {
+    FETCH_PUBLIC_LEVELS({ commit }): void {
       if (auth.currentUser) {
-        const publicLevels: any = []
+        const publicLevels: ISavedLevelMetadata[] = []
         const docs = db.collection('levels').where('public', '==', true)
 
         docs
@@ -318,7 +326,7 @@ const userModule: Module<IUserState, IRootState> = {
         console.log('You are not logged in!')
       }
     },
-    MAKE_LEVEL_PUBLIC({ commit, dispatch }, levelID) {
+    MAKE_LEVEL_PUBLIC({ commit, dispatch }, levelID): void {
       if (auth.currentUser) {
         const docs = db
           .collection('levels')
@@ -344,7 +352,7 @@ const userModule: Module<IUserState, IRootState> = {
         console.log('You are not logged in!')
       }
     },
-    MAKE_LEVEL_PRIVATE({ commit, dispatch }, levelID) {
+    MAKE_LEVEL_PRIVATE({ commit, dispatch }, levelID): void {
       if (auth.currentUser) {
         const doc = db.collection('levels').doc(levelID)
 
@@ -360,8 +368,7 @@ const userModule: Module<IUserState, IRootState> = {
         console.log('You are not logged in!')
       }
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    REMOVE_LEVEL({ commit, dispatch }, levelID) {
+    REMOVE_LEVEL({ commit }, levelID): void {
       const dbRef = db.collection('levels')
 
       dbRef
@@ -375,7 +382,7 @@ const userModule: Module<IUserState, IRootState> = {
           commit('SET_ERROR', err.message, { root: true })
         })
     },
-    GET_LEVEL_DATA({ commit }, { id }) {
+    GET_LEVEL_DATA({ commit }, { id }): void {
       db.collection('levels')
         .doc(id)
         .get()
@@ -392,10 +399,10 @@ const userModule: Module<IUserState, IRootState> = {
           commit('SET_ERROR', err.message, { root: true })
         })
     },
-    CLEAR_LEVEL_DATA({ commit }) {
+    CLEAR_LEVEL_DATA({ commit }): void {
       commit('RESET_FETCHED_LEVEL')
     },
-    UPDATE_LEVEL_LISTS({ dispatch }) {
+    UPDATE_LEVEL_LISTS({ dispatch }): void {
       dispatch('FETCH_MY_LEVELS')
       dispatch('FETCH_PUBLIC_LEVELS')
     },

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -219,6 +219,7 @@ const userModule: Module<IUserState, IRootState> = {
           },
           public: false,
           createdAt: firebase.firestore.Timestamp.fromDate(new Date()),
+          lastModified: firebase.firestore.Timestamp.fromDate(new Date()),
         }
 
         const dbRef = db.collection('levels')
@@ -248,7 +249,7 @@ const userModule: Module<IUserState, IRootState> = {
             boardState: level.boardState,
           },
           // created for firestore update test
-          lastModifed: firebase.firestore.Timestamp.fromDate(new Date()),
+          lastModified: firebase.firestore.Timestamp.fromDate(new Date()),
         }
         const levelSaved = router.currentRoute.params.id
 
@@ -274,6 +275,8 @@ const userModule: Module<IUserState, IRootState> = {
                 id: doc.id,
                 link: `/level/${doc.id}`,
                 public: doc.data().public,
+                createdAt: doc.data().createdAt,
+                lastModified: doc.data().lastModified,
               })
             })
           })
@@ -297,7 +300,11 @@ const userModule: Module<IUserState, IRootState> = {
           .then((querySnapshot) => {
             querySnapshot.forEach(function(doc) {
               publicLevels.push({
-                link: `/levels/shared/${doc.id}`,
+                id: doc.id,
+                link: `/levels/${doc.id}`,
+                public: doc.data().public, // always true
+                createdAt: doc.data().createdAt,
+                lastModified: doc.data().lastModified,
               })
             })
           })


### PR DESCRIPTION
- [X] a single repo for public and "private" (unlisted) levels, consistent sharing links
- [X] removed demo things from `myaccount`
- [X] levels are listed with dates
- [ ] shorter level ids (now shorter only for listing)
- [ ] levels `level/:username/:id` or something like that (vide https://jsfiddle.net/stared/1Lbuoxte/)
- [ ] levels `level/:username` for all levels shared by a particular person
- [ ] editable username
- [ ] edit names/links
- [x] types for Firebase database



![image](https://user-images.githubusercontent.com/1001610/79069905-2c834c00-7cd2-11ea-9d71-7df518b79431.png)

![image](https://user-images.githubusercontent.com/1001610/79069895-23927a80-7cd2-11ea-9890-eade6db008d2.png)
