### PR TITLE
perf(Simulation) qt 0.4.9 for speed update

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "global": "^4.4.0",
     "graphlib": "^2.1.7",
     "lodash": "^4.17.19",
-    "quantum-tensors": "^0.4.9",
+    "quantum-tensors": "^0.4.10",
     "register-service-worker": "^1.6.2",
     "tone": "^13.8.25",
     "vue": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "global": "^4.4.0",
     "graphlib": "^2.1.7",
     "lodash": "^4.17.19",
-    "quantum-tensors": "^0.4.7",
+    "quantum-tensors": "^0.4.9",
     "register-service-worker": "^1.6.2",
     "tone": "^13.8.25",
     "vue": "^2.6.10",

--- a/src/engine/QuantumFrame.ts
+++ b/src/engine/QuantumFrame.ts
@@ -80,11 +80,8 @@ export default class QuantumFrame {
       throw new Error('You cannot propagateAndInteract more times with the same frame!')
     }
 
-    console.log('BEFORE', this.photons.ketString())
     this.photons.propagatePhotons()
-    console.log('PROPAGATION', this.photons.ketString())
     this.probPropagated = this.probability
-    // TODO: Rework array into interface
     this.absorptions = operatorList
       .map(
         ({ x, y, op }): IDetection => {
@@ -102,8 +99,6 @@ export default class QuantumFrame {
       })
     }
     this.photons.actOnSinglePhotons()
-    // console.log('dU', this.photons.cachedDiffU.toString())
-    console.log('ACTION', this.photons.ketString())
     this.probAfter = this.probability
   }
 

--- a/src/engine/QuantumFrame.ts
+++ b/src/engine/QuantumFrame.ts
@@ -75,19 +75,22 @@ export default class QuantumFrame {
     return this.photons.vector.normSquared()
   }
 
-  public propagateAndInteract(operatorList: [number, number, qt.Operator][]): void {
+  public propagateAndInteract(operatorList: qt.interfaces.IXYOperator[]): void {
     if (this.probPropagated !== undefined) {
       throw new Error('You cannot propagateAndInteract more times with the same frame!')
     }
+
+    console.log('BEFORE', this.photons.ketString())
     this.photons.propagatePhotons()
+    console.log('PROPAGATION', this.photons.ketString())
     this.probPropagated = this.probability
     // TODO: Rework array into interface
     this.absorptions = operatorList
       .map(
-        ([x, y, op]): IDetection => {
+        ({ x, y, op }): IDetection => {
           return {
             coord: { x, y },
-            probability: this.photons.measureAbsorptionAtOperator(x, y, op),
+            probability: this.photons.measureAbsorptionAtOperator({ x, y, op }),
           }
         }
       )
@@ -98,7 +101,9 @@ export default class QuantumFrame {
         probability: this.probBefore - this.probPropagated,
       })
     }
-    this.photons.actOnSinglePhotons(operatorList.map(([x, y, op]) => ({ x, y, op })))
+    this.photons.actOnSinglePhotons()
+    // console.log('dU', this.photons.cachedDiffU.toString())
+    console.log('ACTION', this.photons.ketString())
     this.probAfter = this.probability
   }
 

--- a/src/engine/QuantumSimulation.ts
+++ b/src/engine/QuantumSimulation.ts
@@ -1,5 +1,5 @@
 import { sumBy, groupBy, map } from 'lodash'
-import { Vector, Photons } from 'quantum-tensors'
+import { Vector, Photons, interfaces } from 'quantum-tensors'
 import { weightedRandomInt } from '@/engine/Helpers'
 import { IIndicator, PolEnum, IAbsorption } from '@/engine/interfaces'
 import Coord from '@/engine/Coord'
@@ -15,10 +15,17 @@ import QuantumFrame from '@/engine/QuantumFrame'
 export default class QuantumSimulation {
   private grid: Grid
   public frames: QuantumFrame[]
+  public xyops: interfaces.IXYOperator[]
 
   public constructor(grid: Grid) {
     this.grid = grid
     this.frames = []
+    this.xyops = this.grid.operatorList.map(([x, y, op]) => ({
+      x,
+      y,
+      op,
+    }))
+    console.log('xyops', this.xyops)
   }
 
   /**
@@ -46,6 +53,7 @@ export default class QuantumSimulation {
       laserIndicator.direction,
       laserIndicator.polarization
     )
+    initFrame.photons.updateOperators(this.xyops)
     this.frames.push(initFrame)
   }
 
@@ -62,6 +70,7 @@ export default class QuantumSimulation {
       indicator.direction,
       indicator.polarization
     )
+    frame.photons.updateOperators(this.xyops)
     this.frames.push(frame)
   }
 
@@ -80,7 +89,7 @@ export default class QuantumSimulation {
         .outer(vecDirPol.permute([1, 0]))
         .toBasisAll('polarization', 'HV')
     }
-
+    frame.photons.updateOperators(this.xyops)
     this.frames.push(frame)
   }
 
@@ -103,7 +112,7 @@ export default class QuantumSimulation {
       )
     }
     const frame = QuantumFrame.fromPhotons(this.lastFrame.photons)
-    frame.propagateAndInteract(this.grid.operatorList)
+    frame.propagateAndInteract(this.xyops)
     return frame
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9619,18 +9619,18 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-quantum-tensors@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/quantum-tensors/-/quantum-tensors-0.4.7.tgz#49dbc7925a3b499f23e0578982028c6e2d381085"
-  integrity sha512-DLPTSzyREY3PBInKN+vrBymQw/bRu21eZW43VWKWCa3VHJHI9wTrCutuG9s4pHc8y1ENh5UblvaC0zRLYXZhfA==
+quantum-tensors@^0.4.10:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/quantum-tensors/-/quantum-tensors-0.4.10.tgz#cad1ad37898380ecdca9f3368ab788180a5c95b0"
+  integrity sha512-SDZ/CvJAN8C+8YnqUBj6l5CEhmQ4uNolMDieju/7D829HfoYLOHkd2kaA0uZ12QD6R0HD/4QR8mosNVCgBxCCw==
   dependencies:
     "@types/lodash" "^4.14.138"
     lodash "^4.17.15"
 
-quantum-tensors@^0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/quantum-tensors/-/quantum-tensors-0.4.9.tgz#2999973c06090e099bf49756b81e8d0997e7f850"
-  integrity sha512-X0VLc6HGG2W+sxf1NlkXiMLKCLYzEb34alDR+HMFqpoGK0d2FhHZJmXIytP7CxOs2wC9W4KHRErChsWWPqMGjQ==
+quantum-tensors@^0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/quantum-tensors/-/quantum-tensors-0.4.7.tgz#49dbc7925a3b499f23e0578982028c6e2d381085"
+  integrity sha512-DLPTSzyREY3PBInKN+vrBymQw/bRu21eZW43VWKWCa3VHJHI9wTrCutuG9s4pHc8y1ENh5UblvaC0zRLYXZhfA==
   dependencies:
     "@types/lodash" "^4.14.138"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9627,6 +9627,14 @@ quantum-tensors@^0.4.7:
     "@types/lodash" "^4.14.138"
     lodash "^4.17.15"
 
+quantum-tensors@^0.4.9:
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/quantum-tensors/-/quantum-tensors-0.4.9.tgz#2999973c06090e099bf49756b81e8d0997e7f850"
+  integrity sha512-X0VLc6HGG2W+sxf1NlkXiMLKCLYzEb34alDR+HMFqpoGK0d2FhHZJmXIytP7CxOs2wC9W4KHRErChsWWPqMGjQ==
+  dependencies:
+    "@types/lodash" "^4.14.138"
+    lodash "^4.17.15"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"


### PR DESCRIPTION
I try to use new performance updates from quantum-tensors 0.4.9, see https://github.com/Quantum-Game/quantum-tensors/pull/32.

However, even tests in https://github.com/Quantum-Game/quantum-tensors/blob/master/tests/Photons.test.ts pass (see https://travis-ci.com/github/Quantum-Game/quantum-tensors/builds/181135173) we get errors in the game: 

<img width="778" alt="Screenshot 2020-08-25 at 22 57 10" src="https://user-images.githubusercontent.com/1001610/91227183-5f305d00-e726-11ea-9671-c1a8dd6b12bb.png">

It seems that with each operation, instead of `newVec = diffU.mul(oldVec) + oldVec` we get `newVec = U.mul(oldVec) + oldVec`. So that, among other issues:

* if nothing happens, a beam gets multiplied by a factor 2
* if something absorbs a beam, it still goes through it

I look at the errors, and so far it seems that:

`this.photons.cachedDiffU` in `QuantumFrame.ts` gives wrong results (instead of only elements, it contains identity). I don't have any idea why.


