### PR TITLE
rename incorrectly named controller to Playhead

### DIFF
--- a/src/components/EncyclopediaPage/BoardFramePicker.vue
+++ b/src/components/EncyclopediaPage/BoardFramePicker.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="btn-group">
-    <span v-for="index in scrubber.totalFrames" :key="index" @mouseover="scrubber.seek(index - 1)">
-      <button :class="{ selected: scrubber.frameIndex === index - 1 }"></button>
+    <span v-for="index in playhead.totalFrames" :key="index" @mouseover="playhead.seek(index - 1)">
+      <button :class="{ selected: playhead.frameIndex === index - 1 }"></button>
     </span>
   </div>
 </template>
 <script lang="ts">
-import { ScrubberController } from '@/engine/controller'
+import { PlayheadController } from '@/engine/controller'
 import { defineComponent, PropType } from 'vue'
 
 export default defineComponent({
-  props: { scrubber: { type: Object as PropType<ScrubberController>, required: true } },
+  props: { playhead: { type: Object as PropType<PlayheadController>, required: true } },
 })
 </script>
 <style lang="scss" scoped>

--- a/src/components/EncyclopediaPage/EncyclopediaBoard.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaBoard.vue
@@ -5,14 +5,14 @@
       :absorptions="gameCtl.sim.absorptions"
       :board="gameCtl.level.board"
       :laser-particles="laserParticles"
-      :particles="scrubberCtl.activeFrame.particles"
+      :particles="playheadCtl.activeFrame.particles"
       @touch="updateRotation"
     />
-    <board-frame-picker :scrubber="scrubberCtl" />
+    <board-frame-picker :playhead="playheadCtl" />
     <div class="ket">
       <ket-viewer
         :key="polBasis"
-        :vector="scrubberCtl.activeFrame.vector"
+        :vector="playheadCtl.activeFrame.vector"
         :initial-pol-basis="polBasis"
       />
     </div>
@@ -24,7 +24,7 @@ import { KetViewer } from 'bra-ket-vue'
 import Board from '@/components/Board/index.vue'
 import BoardFramePicker from './BoardFramePicker.vue'
 import { computed, defineComponent, PropType } from 'vue'
-import { gameController, scrubberController } from '@/engine/controller'
+import { gameController, playheadController } from '@/engine/controller'
 import { IGrid } from '@/engine/interfaces'
 import { Coord, Rotation, Vector } from '@/engine/model'
 
@@ -51,11 +51,11 @@ export default defineComponent({
 
     gameCtl.importLevel({ grid: props.grid })
 
-    const scrubberCtl = scrubberController({
+    const playheadCtl = playheadController({
       frames: () => gameCtl.sim?.frames.filter((f) => f.vector.entries.length > 0) ?? [],
       rewindOnUpdate: false,
     })
-    scrubberCtl.seek(props.defaultStep ?? 0)
+    playheadCtl.seek(props.defaultStep ?? 0)
 
     const laserParticles = computed(() => {
       return gameCtl.sim?.frames.flatMap((f) => f.particles) ?? []
@@ -73,7 +73,7 @@ export default defineComponent({
       }
     }
 
-    return { gameCtl, scrubberCtl, laserParticles, polBasis, updateRotation }
+    return { gameCtl, playheadCtl, laserParticles, polBasis, updateRotation }
   },
 })
 </script>

--- a/src/components/GamePage/GameControls.vue
+++ b/src/components/GamePage/GameControls.vue
@@ -6,20 +6,20 @@
       <button
         type="button"
         :style="styles.back"
-        @click="scrubber.stepBack()"
+        @click="playhead.stepBack()"
         @mouseenter="$emit('hover', { kind: 'ui', text: 'Simulation: one step back.' })"
       />
       <button
         id="play"
         type="button"
         :style="styles.play"
-        @click="scrubber.toggle()"
+        @click="playhead.toggle()"
         @mouseenter="$emit('hover', { kind: 'ui', text: 'Run the simulation.' })"
       />
       <button
         type="button"
         :style="styles.forward"
-        @click="scrubber.stepForward()"
+        @click="playhead.stepForward()"
         @mouseenter="$emit('hover', { kind: 'ui', text: 'Simulation: the next step.' })"
       />
       <!-- <button type="button" :style="styles.fastForward" @click="$emit('fast-forward')" /> -->
@@ -73,7 +73,7 @@ import { IStyle } from '@/types'
 import { validateInfoPayload } from '@/mixins/gameInterfaces'
 import { storeNamespace } from '@/store'
 import { computed, defineComponent, PropType, proxyRefs } from 'vue'
-import { ScrubberController } from '@/engine/controller'
+import { PlayheadController } from '@/engine/controller'
 
 const user = storeNamespace('user')
 const options = storeNamespace('options')
@@ -99,7 +99,7 @@ const icons = {
 
 export default defineComponent({
   props: {
-    scrubber: { type: Object as PropType<ScrubberController>, required: true },
+    playhead: { type: Object as PropType<PlayheadController>, required: true },
   },
   emits: {
     hover: validateInfoPayload,
@@ -114,10 +114,10 @@ export default defineComponent({
     const isLoggedIn = user.useGetter('isLoggedIn')
 
     const displayStatus = computed(() => {
-      if (props.scrubber.isPlaying) {
+      if (props.playhead.isPlaying) {
         // (each time a random outcome)
         return 'Quantum simulation (live)'
-      } else if (props.scrubber.frameIndex > 0) {
+      } else if (props.playhead.frameIndex > 0) {
         return 'Quantum simulation (step-by-step)'
       } else {
         // (still with polarization & interference)
@@ -134,25 +134,25 @@ export default defineComponent({
 
     const styles = proxyRefs({
       rewind: computed(() =>
-        iconStyle('rewind', !props.scrubber.isPlaying && !props.scrubber.isFirstFrame)
+        iconStyle('rewind', !props.playhead.isPlaying && !props.playhead.isFirstFrame)
       ),
       back: computed(() =>
-        iconStyle('origStepBack', !props.scrubber.isPlaying && !props.scrubber.isFirstFrame)
+        iconStyle('origStepBack', !props.playhead.isPlaying && !props.playhead.isFirstFrame)
       ),
-      play: computed(() => iconStyle(props.scrubber.isPlaying ? 'pause' : 'play', true)),
+      play: computed(() => iconStyle(props.playhead.isPlaying ? 'pause' : 'play', true)),
       forward: computed(() =>
-        iconStyle('origStepForward', !props.scrubber.isPlaying && !props.scrubber.isLastFrame)
+        iconStyle('origStepForward', !props.playhead.isPlaying && !props.playhead.isLastFrame)
       ),
       fastForward: computed(() =>
-        iconStyle('fastForward', !props.scrubber.isPlaying && !props.scrubber.isLastFrame)
+        iconStyle('fastForward', !props.playhead.isPlaying && !props.playhead.isLastFrame)
       ),
-      reload: computed(() => iconStyle('reload', !props.scrubber.isPlaying)),
+      reload: computed(() => iconStyle('reload', !props.playhead.isPlaying)),
       sound: computed(() =>
-        iconStyle(soundActive.value ? 'soundOff' : 'soundOn', !props.scrubber.isPlaying)
+        iconStyle(soundActive.value ? 'soundOff' : 'soundOn', !props.playhead.isPlaying)
       ),
-      download: computed(() => iconStyle('download', !props.scrubber.isPlaying)),
-      upload: computed(() => iconStyle('upload', !props.scrubber.isPlaying)),
-      save: computed(() => iconStyle('save', isLoggedIn.value && !props.scrubber.isPlaying)),
+      download: computed(() => iconStyle('download', !props.playhead.isPlaying)),
+      upload: computed(() => iconStyle('upload', !props.playhead.isPlaying)),
+      save: computed(() => iconStyle('save', isLoggedIn.value && !props.playhead.isPlaying)),
     })
 
     function showSoundHint() {

--- a/src/components/GamePage/index.vue
+++ b/src/components/GamePage/index.vue
@@ -56,7 +56,7 @@
             @hover="updateInfoPayload"
           />
           <game-controls
-            :scrubber="scrubberCtl"
+            :playhead="playheadCtl"
             @reload="reload"
             @download="downloadLevel"
             @upload="loadJsonLevelFromFile"
@@ -72,9 +72,9 @@
           <GameGoals :goals="gameCtl.goals" />
           <div class="ket-viewer-game">
             <ket-viewer
-              v-if="scrubberCtl.activeFrame"
+              v-if="playheadCtl.activeFrame"
               class="ket"
-              :vector="scrubberCtl.activeFrame.vector"
+              :vector="playheadCtl.activeFrame.vector"
             />
           </div>
         </section>
@@ -110,7 +110,7 @@ import { useWindowEvent, usePerRouteFlag, useMouseCoords } from '@/mixins'
 import {
   GameOutcome,
   gameController,
-  scrubberController,
+  playheadController,
   GrabSource,
   GrabState,
 } from '@/engine/controller'
@@ -141,7 +141,7 @@ export default defineComponent({
     const alreadyWon = usePerRouteFlag()
 
     const gameCtl = gameController()
-    const scrubberCtl = scrubberController({
+    const playheadCtl = playheadController({
       frames: () => gameCtl.sim?.frames ?? [],
       rewindOnUpdate: true,
     })
@@ -177,11 +177,11 @@ export default defineComponent({
       switch (e.key) {
         case ' ':
           e.preventDefault()
-          return scrubberCtl.toggle()
+          return playheadCtl.toggle()
         case 'ArrowLeft':
-          return scrubberCtl.stepBack()
+          return playheadCtl.stepBack()
         case 'ArrowRight':
-          return scrubberCtl.stepForward()
+          return playheadCtl.stepForward()
       }
     })
 
@@ -244,7 +244,7 @@ export default defineComponent({
      * @returns particles
      */
     const activeParticles = computed((): Particle[] => {
-      return scrubberCtl.activeFrame?.particles ?? []
+      return playheadCtl.activeFrame?.particles ?? []
     })
 
     /**
@@ -263,7 +263,7 @@ export default defineComponent({
     })
 
     const overlayGameState = computed(() => {
-      if (!alreadyWon.flag && scrubberCtl.isLastFrame) {
+      if (!alreadyWon.flag && playheadCtl.isLastFrame) {
         switch (gameCtl.goals.gameOutcome) {
           case GameOutcome.Victory:
             return 'Victory'
@@ -293,7 +293,7 @@ export default defineComponent({
 
     function continueAfterWin(): void {
       alreadyWon.set()
-      scrubberCtl.rewind()
+      playheadCtl.rewind()
     }
 
     /**
@@ -326,7 +326,7 @@ export default defineComponent({
       const piece = gameCtl.level?.board.pieces.get(coord)
       if (piece == null) return
       if (piece.type === Elem.Laser) {
-        scrubberCtl.toggle()
+        playheadCtl.toggle()
       } else {
         gameCtl.rotateCcw(coord)
       }
@@ -334,7 +334,7 @@ export default defineComponent({
 
     return {
       gameCtl,
-      scrubberCtl,
+      playheadCtl,
       dragState,
       previousLevel,
       nextLevel,

--- a/src/engine/controller/index.ts
+++ b/src/engine/controller/index.ts
@@ -1,2 +1,2 @@
 export * from './game'
-export * from './scrubber'
+export * from './playhead'

--- a/src/engine/controller/playhead.ts
+++ b/src/engine/controller/playhead.ts
@@ -2,10 +2,10 @@ import { useTimer } from '@/mixins/timer'
 import { computed, proxyRefs, ref, watch } from 'vue'
 import { Frame } from '../model'
 
-export function scrubberController(options: {
+export function playheadController(options: {
   rewindOnUpdate: boolean
   frames: () => Frame[]
-}): ScrubberController {
+}): PlayheadController {
   const targetFrameIndex = ref(0)
   const isPlaying = ref(false)
 
@@ -86,7 +86,7 @@ export function scrubberController(options: {
   })
 }
 
-export interface ScrubberController {
+export interface PlayheadController {
   readonly isPlaying: boolean
   readonly isFirstFrame: boolean
   readonly isLastFrame: boolean


### PR DESCRIPTION
The "scrubber" name, while [almost correct](https://en.wikipedia.org/wiki/Scrubbing_(audio)) (although wikipedia says it's specific to audio), seems to be [heavily overloaded](https://en.wikipedia.org/wiki/Scrubbing) and not commonly understood. Changed the name to `Playhead` which should be more familiar.