### PR TITLE
Homepage redesign

### DIFF
--- a/src/components/HomePage/HomepageAuthors.vue
+++ b/src/components/HomePage/HomepageAuthors.vue
@@ -2,7 +2,7 @@
   <p class="authors">
     Quantum Game is being developed by Quantum Flytrap, founded by
     <a href="https://p.migdal.pl/" target="_blank">Piotr Migdał</a> and
-    <a href="http://jankiewiczstudio.com/" target="_blank">Klem Jankiewicz</a>. Key employees: Paweł
+    <a href="http://jankiewiczstudio.com/" target="_blank">Klem Jankiewicz</a>. The current team includes: Paweł
     Grabarz, Natalia H. Wileńska, Philippe Cochin, Chiara Decaroli. Generative soundtrack by
     <a href="https://www.paweljanicki.jp/" target="_blank">Pawel Janicki</a>.
     <br />
@@ -14,7 +14,7 @@
 
 <style lang="scss" scoped>
 a {
-  color: rgb(255, 181, 209);
+  color: #eab5ff;
   text-decoration: none;
 }
 a:hover {

--- a/src/components/HomePage/HomepageHistory.vue
+++ b/src/components/HomePage/HomepageHistory.vue
@@ -21,10 +21,15 @@
 <style lang="scss" scoped>
 a {
   color: #eab5ff;
-  //text-decoration: none;
+  text-decoration: none;
 }
 a:hover {
   color: white;
+}
+.history {
+  border-top: 2px solid white;
+  padding-top: 30px;
+  line-height: 1.5;
 }
 .CQTlogo {
   width: 40%;

--- a/src/components/HomePage/HomepageHistory.vue
+++ b/src/components/HomePage/HomepageHistory.vue
@@ -20,8 +20,8 @@
 
 <style lang="scss" scoped>
 a {
-  color: rgb(255, 181, 209);
-  text-decoration: none;
+  color: #eab5ff;
+  //text-decoration: none;
 }
 a:hover {
   color: white;

--- a/src/components/HomePage/HomepageInteractive.vue
+++ b/src/components/HomePage/HomepageInteractive.vue
@@ -30,10 +30,14 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 a {
-  color: rgb(255, 181, 209);
+  color: #eab5ff;
   text-decoration: none;
 }
 a:hover {
   color: white;
+}
+.interactive {
+  background: #2e006a;
+  padding: 10px;
 }
 </style>

--- a/src/components/HomePage/HomepageInteractive.vue
+++ b/src/components/HomePage/HomepageInteractive.vue
@@ -38,6 +38,6 @@ a:hover {
 }
 .interactive {
   background: #2e006a;
-  padding: 10px;
+  padding: 30px;
 }
 </style>

--- a/src/components/HomePage/HomepageSocial.vue
+++ b/src/components/HomePage/HomepageSocial.vue
@@ -12,7 +12,7 @@
 
 <style lang="scss" scoped>
 a {
-  color: rgb(255, 181, 209);
+  color: #eab5ff;
   text-decoration: none;
 }
 a:hover {

--- a/src/components/HomePage/HomepageSocial.vue
+++ b/src/components/HomePage/HomepageSocial.vue
@@ -18,4 +18,8 @@ a {
 a:hover {
   color: white;
 }
+.social {
+  border-top: 2px solid white;
+  padding-top: 30px;
+}
 </style>

--- a/src/components/HomePage/HomepageTestimonials.vue
+++ b/src/components/HomePage/HomepageTestimonials.vue
@@ -17,16 +17,14 @@
         </div>
       </div>
     </div>
-    <div class="extra-text">
-      <p>
-        Cited in
-        <a
-          href="https://scholar.google.com/scholar?hl=en&amp;as_sdt=0%2C5&amp;q=%22quantumgame.io%22+OR+%22Quantum+Game+with+Photons%22&amp;btnG="
-          target="_blank"
-          >numerous academic publications</a
-        >, the Top Pick for Education in Gamyfing Quantum Theory, mentioned in VICE and Boing Boing.
-      </p>
-    </div>
+    <p class="extra-text">
+      Cited in
+      <a
+        href="https://scholar.google.com/scholar?hl=en&amp;as_sdt=0%2C5&amp;q=%22quantumgame.io%22+OR+%22Quantum+Game+with+Photons%22&amp;btnG="
+        target="_blank"
+        >numerous academic publications</a
+      >, the Top Pick for Education in Gamyfing Quantum Theory, mentioned in VICE and Boing Boing.
+    </p>
   </div>
 </template>
 

--- a/src/components/HomePage/HomepageTestimonials.vue
+++ b/src/components/HomePage/HomepageTestimonials.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="testimonials" layout="column center u4">
-    <div layout="row wrap">
-      <div v-for="t in testimonials" :key="t.name" layout="column u4" class="testimonial">
+  <div layout="column center u4">
+    <div layout="column" layout-lg="row" class="testimonials-wrap">
+      <div v-for="t in testimonials" :key="t.name" flex layout="column u20" class="testimonial">
         <div flex class="testimonial-text">
           <i>“{{ t.text }}”</i>
         </div>
@@ -83,22 +83,14 @@ a:hover {
   color: white;
 }
 
-.testimonial {
-  // background: rgba(255, 255, 255, 0.479);
-  box-sizing: border-box;
+.testimonials-wrap {
   text-align: left;
-  width: 100%;
-  padding: 20px 40px;
   border-top: 2px solid white;
   border-bottom: 2px solid white;
-  @include media('>=medium') {
-    padding: 20px 20px;
-    width: 33.33%;
-  }
+}
 
-  @include media('>=large') {
-    padding: 20px 40px;
-  }
+.testimonial {
+  padding: 20px 20px;
 }
 
 .testimonial-img {

--- a/src/components/HomePage/HomepageTestimonials.vue
+++ b/src/components/HomePage/HomepageTestimonials.vue
@@ -17,14 +17,16 @@
         </div>
       </div>
     </div>
-    <p>
-      Cited in
-      <a
-        href="https://scholar.google.com/scholar?hl=en&amp;as_sdt=0%2C5&amp;q=%22quantumgame.io%22+OR+%22Quantum+Game+with+Photons%22&amp;btnG="
-        target="_blank"
-        >numerous academic publications</a
-      >, the Top Pick for Education in Gamyfing Quantum Theory, mentioned in VICE and Boing Boing.
-    </p>
+    <div class="extra-text">
+      <p>
+        Cited in
+        <a
+          href="https://scholar.google.com/scholar?hl=en&amp;as_sdt=0%2C5&amp;q=%22quantumgame.io%22+OR+%22Quantum+Game+with+Photons%22&amp;btnG="
+          target="_blank"
+          >numerous academic publications</a
+        >, the Top Pick for Education in Gamyfing Quantum Theory, mentioned in VICE and Boing Boing.
+      </p>
+    </div>
   </div>
 </template>
 
@@ -76,7 +78,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 a {
-  color: rgb(255, 181, 209);
+  color: #eab5ff;
   text-decoration: none;
 }
 a:hover {
@@ -84,14 +86,16 @@ a:hover {
 }
 
 .testimonial {
+  // background: rgba(255, 255, 255, 0.479);
   box-sizing: border-box;
   text-align: left;
   width: 100%;
-
   padding: 20px 40px;
+  border-top: 2px solid white;
+  border-bottom: 2px solid white;
   @include media('>=medium') {
     padding: 20px 20px;
-    width: 33.3%;
+    width: 33.33%;
   }
 
   @include media('>=large') {
@@ -121,5 +125,10 @@ a.testimonial-link {
   color: white;
   text-decoration: underline;
   font-size: 0.8rem;
+}
+
+.extra-text {
+  width: 35%;
+  line-height: 1.5;
 }
 </style>

--- a/src/components/HomePage/index.vue
+++ b/src/components/HomePage/index.vue
@@ -12,8 +12,8 @@
       </router-link>
     </div>
     <div class="hello" layout="column u10">
-      <h2>{{ i18n.t('homepage.main') }}</h2>
-      <h1>{{ i18n.t('homepage.desc') }}</h1>
+      <h1>{{ i18n.t('homepage.main') }}</h1>
+      <p class="main-description">{{ i18n.t('homepage.desc') }}</p>
       <homepage-interactive />
     </div>
     <div class="gameVersion">
@@ -103,12 +103,6 @@ export default defineComponent({
 h1 {
   color: white;
   font-size: 1.4rem;
-  font-weight: normal;
-  line-height: 150%;
-}
-h2 {
-  color: white;
-  font-size: 1.4rem;
   font-weight: 900;
   line-height: 150%;
   margin-top: 50px;
@@ -116,6 +110,9 @@ h2 {
 p {
   color: white;
   line-height: 150%;
+}
+.main-description {
+  font-size: 1.4rem;
 }
 .hello {
   width: 35%;

--- a/src/components/HomePage/index.vue
+++ b/src/components/HomePage/index.vue
@@ -14,6 +14,7 @@
     <div class="hello" layout="column u10">
       <h2>{{ i18n.t('homepage.main') }}</h2>
       <h1>{{ i18n.t('homepage.desc') }}</h1>
+      <homepage-interactive />
     </div>
     <div class="gameVersion">
       <p>
@@ -32,7 +33,6 @@
       </p>
     </div>
     <div class="hello" layout="column u10">
-      <homepage-interactive />
       <homepage-testimonials class="testimonials" />
       <homepage-social />
       <homepage-authors />
@@ -94,7 +94,7 @@ export default defineComponent({
 }
 .gameVersion {
   font-size: 0.8rem;
-  margin: 10px 10px;
+  margin: 20px 10px;
   @include media('<large') {
     font-size: 1rem;
     width: 80%;

--- a/src/components/HomePage/index.vue
+++ b/src/components/HomePage/index.vue
@@ -3,6 +3,18 @@
     <div class="row-full">
       <img src="@/assets/graphics/QG_logo.svg" alt="QuantumGame" />
     </div>
+    <div layout="row wrap middle u5">
+      <router-link to="/level/1">
+        <app-button class="button" type="big">PLAY GAME</app-button>
+      </router-link>
+      <router-link to="/sandbox">
+        <app-button class="button" type="big">VIRTUAL LAB</app-button>
+      </router-link>
+    </div>
+    <div class="hello" layout="column u10">
+      <h2>{{ i18n.t('homepage.main') }}</h2>
+      <h1>{{ i18n.t('homepage.desc') }}</h1>
+    </div>
     <div class="gameVersion">
       <p>
         Version {{ version }} (beta), based on a
@@ -19,17 +31,7 @@
         For optimal experience, play PC (mobile version coming soon).
       </p>
     </div>
-    <div layout="row wrap middle u5">
-      <router-link to="/level/1">
-        <app-button class="button" type="big">PLAY GAME</app-button>
-      </router-link>
-      <router-link to="/sandbox">
-        <app-button class="button" type="big">VIRTUAL LAB</app-button>
-      </router-link>
-    </div>
     <div class="hello" layout="column u10">
-      <h1>{{ i18n.t('homepage.main') }}</h1>
-      <p>{{ i18n.t('homepage.desc') }}</p>
       <homepage-interactive />
       <homepage-testimonials class="testimonials" />
       <homepage-social />
@@ -81,7 +83,8 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: linear-gradient(to right, #210235 16%, #2e006a 30%, #2e006a 70%, #210235 84%);
+  text-align: center;
+  background: linear-gradient(#5c00d3, #f05, #5c00d3, #210235);
   width: 100%;
   & a {
     & img {
@@ -91,6 +94,7 @@ export default defineComponent({
 }
 .gameVersion {
   font-size: 0.8rem;
+  margin: 10px 10px;
   @include media('<large') {
     font-size: 1rem;
     width: 80%;
@@ -101,6 +105,13 @@ h1 {
   font-size: 1.4rem;
   font-weight: normal;
   line-height: 150%;
+}
+h2 {
+  color: white;
+  font-size: 1.4rem;
+  font-weight: 900;
+  line-height: 150%;
+  margin-top: 50px;
 }
 p {
   color: white;
@@ -138,7 +149,7 @@ p {
 }
 
 a {
-  color: rgb(255, 181, 209);
+  color: #eab5ff;
   text-decoration: none;
 }
 a:hover {


### PR DESCRIPTION
Fast changes, TBC
![Screenshot 2020-10-08 at 14 50 07](https://user-images.githubusercontent.com/33489641/95463129-b4dc6400-0978-11eb-8b28-c121d60620a4.png)
These are the things that should be immediately visible for the user:

- Logo
- Buttons (Lab / Game)
- Oneliner
- Short description
- Board

Maybe even the board should be above the description.

**Few other things:**

- version 2.2..... - I moved this down, this should not be the most important information
- testimonials - I tried doing something with them but had some problems (@Frizi happy to talk about this)
- the QG logo - It looks like on bigger screens it'll get to close to the next item (here the buttons)
- SM - I would add social media icons somewhere at the upper part of the page.

**Next steps:**

- visually dividing the homepage into separate parts, blocks
- less text more visual 