### PR TITLE
Next iteration of encyclopedia layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,13 +33,9 @@ body {
   margin: 0;
   padding: 0;
   overflow-x: hidden;
-  @media screen and (max-width: 800px) {
-    // overflow-y: hidden;
-  }
 
   &.menu-opened {
     position: fixed;
-    overflow-y: scroll;
     width: 100%;
     height: 100%;
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,13 @@ body {
   @media screen and (max-width: 800px) {
     // overflow-y: hidden;
   }
+
+  &.menu-opened {
+    position: fixed;
+    overflow-y: scroll;
+    width: 100%;
+    height: 100%;
+  }
 }
 #app {
   display: flex;
@@ -70,8 +77,8 @@ body {
     #210235 84%
   ); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5000a0', endColorstr='#3c1156',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
-  overflow-x: hidden;
 }
+
 #nav {
   padding: 30px;
   a {

--- a/src/assets/data/encyclopedia/concepts.json
+++ b/src/assets/data/encyclopedia/concepts.json
@@ -6,7 +6,7 @@
     "grids": [],
     "sections": [
       {
-        "title": "",
+        "title": "The basics",
         "content": "<p>Amplitude describes the importance of a particular component of a wavefunction.</p>"
       },
       {

--- a/src/assets/styles/breakpoints.scss
+++ b/src/assets/styles/breakpoints.scss
@@ -1,3 +1,5 @@
+$unit: 4px;
+
 $breakpoints: (
     small: 576px, // Small devices (landscape phones, 576px and up)
     medium: 768px, // Medium devices (tablets, 768px and up)

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -1,5 +1,3 @@
-$unit: 4px;
-
 * {
     --layout-margin-parent: 0px;
     --layout-margin-self: 0px;

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="main-layout" layout="column center" flex>
+    <app-menu />
     <div class="main-layout-inner" layout="column" flex>
-      <app-menu />
       <header layout="row between u5">
+        <app-menu-button :class="{ absolute: menuAbsolute, inlineMenu: !menuAbsolute }" />
         <div flex>
           <slot name="header"></slot>
         </div>
@@ -25,14 +26,17 @@
 
 <script lang="ts">
 import AppMenu from '@/components/AppMenu.vue'
+import AppMenuButton from '@/components/AppMenuButton.vue'
 import { defineComponent } from 'vue'
 
 export default defineComponent({
   components: {
     AppMenu,
+    AppMenuButton,
   },
   props: {
     leftClass: { type: String, default: '' },
+    menuAbsolute: { type: Boolean, default: true },
   },
 })
 </script>
@@ -43,6 +47,11 @@ export default defineComponent({
   width: 100vw;
   min-height: 100vh;
   color: white;
+  padding: 0 20px;
+}
+
+.inlineMenu {
+  padding: 10px 0;
 }
 
 @include media('>=large') {
@@ -50,10 +59,5 @@ export default defineComponent({
   .right {
     width: 200px;
   }
-}
-
-main,
-header {
-  padding: 0 20px;
 }
 </style>

--- a/src/components/AppMenu.vue
+++ b/src/components/AppMenu.vue
@@ -47,7 +47,9 @@ export default defineComponent(() => {
   watchEffect(() => {
     if (appMenuOpened.value) {
       preservedOffset = window.scrollY
-      document.body.setAttribute('style', `top: ${-preservedOffset}px`)
+      const scrollbarVisible = document.body.scrollHeight > window.innerHeight
+      const overflowY = scrollbarVisible ? 'scroll' : 'auto'
+      document.body.setAttribute('style', `top: ${-preservedOffset}px; overflow-y: ${overflowY};`)
       document.body.classList.add('menu-opened')
     } else {
       document.body.classList.remove('menu-opened')

--- a/src/components/AppMenu.vue
+++ b/src/components/AppMenu.vue
@@ -47,7 +47,6 @@ export default defineComponent(() => {
   watchEffect(() => {
     if (appMenuOpened.value) {
       preservedOffset = window.scrollY
-      console.log(window.scrollY)
       document.body.setAttribute('style', `top: ${-preservedOffset}px`)
       document.body.classList.add('menu-opened')
     } else {

--- a/src/components/AppMenu.vue
+++ b/src/components/AppMenu.vue
@@ -1,11 +1,6 @@
 <template>
-  <div :class="{ open: isMenuOpen, 'menu-icon': true }" @click="toggleMenu">
-    <div class="bar1"></div>
-    <div class="bar2"></div>
-    <div class="bar3"></div>
-  </div>
   <transition name="fade">
-    <div v-if="isMenuOpen" class="menu-overlay" flex layout="column">
+    <div v-if="appMenuOpened" class="menu-overlay" flex layout="column">
       <menu layout="column around u1">
         <router-link to="/">BACK TO THE MAIN PAGE</router-link>
         <router-link v-if="currentLevel != null" :to="`/level/${currentLevel}`">
@@ -27,84 +22,50 @@
 <script lang="ts">
 import { useWindowEvent } from '@/mixins/event'
 import { storeNamespace } from '@/store'
-import { defineComponent, ref } from 'vue'
+import { defineComponent, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
 
-const user = storeNamespace('user')
-const game = storeNamespace('game')
-
 export default defineComponent(() => {
+  const user = storeNamespace('user')
+  const game = storeNamespace('game')
   const isLoggedIn = user.useGetter('isLoggedIn')
   const currentLevel = game.useState('currentLevelID')
-  const router = useRouter()
-  const isMenuOpen = ref(false)
+  const appMenuOpened = game.useState('appMenuOpened')
+  const SET_MENU_OPENED = game.useMutation('SET_MENU_OPENED')
 
   useWindowEvent('keydown', (e) => {
     if (e.key === 'Escape') {
-      toggleMenu()
+      SET_MENU_OPENED(!appMenuOpened.value)
     }
   })
 
-  router.afterEach(() => {
-    isMenuOpen.value = false
+  useRouter().afterEach(() => {
+    SET_MENU_OPENED(false)
   })
 
-  function toggleMenu(): void {
-    isMenuOpen.value = !isMenuOpen.value
-  }
+  let preservedOffset = 0
+  watchEffect(() => {
+    if (appMenuOpened.value) {
+      preservedOffset = window.scrollY
+      console.log(window.scrollY)
+      document.body.setAttribute('style', `top: ${-preservedOffset}px`)
+      document.body.classList.add('menu-opened')
+    } else {
+      document.body.classList.remove('menu-opened')
+      document.body.setAttribute('style', '')
+      window.scrollTo(0, preservedOffset)
+    }
+  })
 
   return {
-    toggleMenu,
     isLoggedIn,
     currentLevel,
-    isMenuOpen,
+    appMenuOpened,
   }
 })
 </script>
 
 <style scoped lang="scss">
-.menu-icon {
-  display: block;
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  cursor: pointer;
-  z-index: 4;
-
-  .bar1,
-  .bar2,
-  .bar3 {
-    width: 35px;
-    height: 3px;
-    background-color: rgb(255, 255, 255);
-    margin: 8px 0;
-    transition: 0.4s;
-    @include media('<large') {
-      width: 6vw;
-      height: 0.5vw;
-      margin: 1vw 0;
-    }
-  }
-
-  &.open {
-    position: fixed;
-    .bar1 {
-      transform: rotate(-45deg) translate(-7px, 3px);
-      @include media('<large') {
-        transform: rotate(-45deg) translate(-1.2vw, 1.2vw);
-      }
-    }
-    .bar2 {
-      opacity: 0;
-    }
-    .bar3 {
-      transform: rotate(45deg) translate(-11px, -11px);
-      @include media('<large') {
-        transform: rotate(45deg) translate(-1vw, -1vw);
-      }
-    }
-  }
-}
 .menu-overlay {
   z-index: 3;
   position: fixed;

--- a/src/components/AppMenuButton.vue
+++ b/src/components/AppMenuButton.vue
@@ -31,7 +31,7 @@ export default defineComponent(() => {
     (opened) => {
       if (opened && button.value != null) {
         const rect = button.value.getBoundingClientRect()
-        offsetTop.value = rect.top
+        offsetTop.value = rect.top - 30
       } else {
         offsetTop.value = 0
       }
@@ -69,7 +69,7 @@ export default defineComponent(() => {
   display: block;
   cursor: pointer;
   z-index: 4;
-  transition: transform 0.1s;
+  transition: transform 0.15s ease-out;
   transform: translateY(0px);
 
   .bar1,

--- a/src/components/AppMenuButton.vue
+++ b/src/components/AppMenuButton.vue
@@ -1,5 +1,10 @@
 <template>
-  <div :class="{ open: appMenuOpened, 'menu-icon': true }" @click="toggleMenu">
+  <div
+    ref="button"
+    :class="{ open: appMenuOpened, 'menu-icon': true }"
+    :style="style"
+    @click="toggleMenu"
+  >
     <div class="bar1"></div>
     <div class="bar2"></div>
     <div class="bar3"></div>
@@ -8,18 +13,40 @@
 
 <script lang="ts">
 import { storeNamespace } from '@/store'
-import { defineComponent } from 'vue'
+import { computed, defineComponent, ref, watch } from 'vue'
 
 export default defineComponent(() => {
   const game = storeNamespace('game')
   const appMenuOpened = game.useState('appMenuOpened')
   const SET_MENU_OPENED = game.useMutation('SET_MENU_OPENED')
+  const button = ref<HTMLElement>()
 
   function toggleMenu(): void {
     SET_MENU_OPENED(!appMenuOpened.value)
   }
 
+  const offsetTop = ref(0)
+  watch(
+    () => appMenuOpened.value,
+    (opened) => {
+      if (opened && button.value != null) {
+        const rect = button.value.getBoundingClientRect()
+        offsetTop.value = rect.top
+      } else {
+        offsetTop.value = 0
+      }
+    }
+  )
+
+  const style = computed(() => {
+    return {
+      transform: `translateY(${-offsetTop.value}px)`,
+    }
+  })
+
   return {
+    button,
+    style,
     toggleMenu,
     appMenuOpened,
   }
@@ -42,6 +69,8 @@ export default defineComponent(() => {
   display: block;
   cursor: pointer;
   z-index: 4;
+  transition: transform 0.1s;
+  transform: translateY(0px);
 
   .bar1,
   .bar2,

--- a/src/components/AppMenuButton.vue
+++ b/src/components/AppMenuButton.vue
@@ -1,0 +1,70 @@
+<template>
+  <div :class="{ open: appMenuOpened, 'menu-icon': true }" @click="toggleMenu">
+    <div class="bar1"></div>
+    <div class="bar2"></div>
+    <div class="bar3"></div>
+  </div>
+</template>
+
+<script lang="ts">
+import { storeNamespace } from '@/store'
+import { defineComponent } from 'vue'
+
+export default defineComponent(() => {
+  const game = storeNamespace('game')
+  const appMenuOpened = game.useState('appMenuOpened')
+  const SET_MENU_OPENED = game.useMutation('SET_MENU_OPENED')
+
+  function toggleMenu(): void {
+    SET_MENU_OPENED(!appMenuOpened.value)
+  }
+
+  return {
+    toggleMenu,
+    appMenuOpened,
+  }
+})
+</script>
+
+<style scoped lang="scss">
+.menu-icon.absolute {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+
+  &.open {
+    position: fixed;
+  }
+}
+
+.menu-icon {
+  position: relative;
+  display: block;
+  cursor: pointer;
+  z-index: 4;
+
+  .bar1,
+  .bar2,
+  .bar3 {
+    width: 35px;
+    height: 3px;
+    background-color: rgb(255, 255, 255);
+    margin: 8px 0;
+    transition: transform 0.3s, opacity 0.3s;
+    transform-origin: 50% 50%;
+  }
+
+  &.open {
+    .bar1 {
+      transform: translate(0px, 11px) rotate(-45deg);
+    }
+    .bar2 {
+      transform: rotateY(90deg);
+      opacity: 0;
+    }
+    .bar3 {
+      transform: translate(0px, -11px) rotate(45deg);
+    }
+  }
+}
+</style>

--- a/src/components/EncyclopediaPage/EncyclopediaArticle.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaArticle.vue
@@ -1,10 +1,12 @@
 <template>
-  <div layout="column">
+  <div layout="column u4">
+    <!-- TITLE -->
+    <h1 class="title">{{ entry.title }}</h1>
     <!-- eslint-disable-next-line vue/no-v-html -->
     <h2 class="short" v-html="entry.short" />
     <!-- GRIDS -->
     <div class="grids">
-      <div layout="row wrap around u5">
+      <div layout="row wrap start u5">
         <encyclopedia-board
           v-for="(iGrid, i) in entry.grids"
           :key="i"
@@ -87,18 +89,16 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.title {
+  text-transform: uppercase;
+  font-size: 2em;
+}
+
 .short {
   font-size: 1rem;
-  padding-right: 20%;
-  padding-left: 20%;
   padding-bottom: 20px;
   font-weight: 300;
   line-height: 1.5rem;
   letter-spacing: 0.5px;
-  text-align: center;
-}
-
-.grids {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }
 </style>

--- a/src/components/EncyclopediaPage/EncyclopediaLinkList.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaLinkList.vue
@@ -1,14 +1,16 @@
 <template>
   <div class="element-list" :class="{ entriesExpanded }" layout="column">
     <h3 v-if="title" @click="toggleEntries">{{ title }}</h3>
-    <router-link v-for="entry in entryList" :key="entry.name" :to="`/info/${entry}`">
-      {{ entryTitle(entry) }}
-    </router-link>
+    <div class="entries">
+      <router-link v-for="entry in sortedList" :key="entry.name" :to="`/info/${entry}`">
+        {{ entryTitle(entry) }}
+      </router-link>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref } from 'vue'
+import { computed, defineComponent, PropType, ref } from 'vue'
 import { getEntry } from './loadData'
 
 export default defineComponent({
@@ -16,9 +18,17 @@ export default defineComponent({
     title: { type: String, required: false },
     entryList: { type: Array as PropType<string[]>, required: true },
   },
-  setup() {
+  setup(props) {
     const entriesExpanded = ref(false)
+    const sortedList = computed(() => {
+      return [...props.entryList].sort((a, b) => {
+        const ta = getEntry(a).title
+        const tb = getEntry(b).title
+        return ta === tb ? 0 : ta > tb ? 1 : -1
+      })
+    })
     return {
+      sortedList,
       entriesExpanded,
       toggleEntries(): void {
         entriesExpanded.value = !entriesExpanded.value
@@ -40,6 +50,14 @@ export default defineComponent({
     margin-top: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
     padding-bottom: 5px;
+  }
+}
+
+.entries {
+  columns: 330px;
+  column-rule: 1px solid rgba(255, 255, 255, 0.3);
+  > a {
+    display: block;
   }
 }
 </style>

--- a/src/components/EncyclopediaPage/EncyclopediaMainPage.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMainPage.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="default-content" layout="column u5" layout-md="row u5">
-    <div flex layout="column u5">
+  <div class="default-content" layout="column u5">
+    <div flex layout="column u5" class="underline">
       <h2>Elements</h2>
-      <div layout="row wrap middle">
+      <div layout="row wrap start" class="elements">
         <router-link
           v-for="link in linkPieces"
           :key="link.to"
@@ -79,17 +79,18 @@ export default defineComponent({
   text-align: center;
 }
 
-h2 {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-  padding-bottom: 5px;
-  text-align: center;
+.elements {
+  margin: auto;
+}
 
-  @include media('>=medium') {
-    text-align: left;
-  }
+h2 {
+  padding-bottom: 5px;
+}
+
+.underline {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .link-list {
-  align-self: center;
 }
 </style>

--- a/src/components/EncyclopediaPage/EncyclopediaSection.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaSection.vue
@@ -28,7 +28,7 @@ export default defineComponent({
 
 <style scoped lang="scss">
 section.entry-section {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
   & .entry-title {
     padding: 1em 0;
     font-size: 1em;

--- a/src/components/EncyclopediaPage/index.vue
+++ b/src/components/EncyclopediaPage/index.vue
@@ -1,15 +1,13 @@
 <template>
-  <app-layout class="encyclopedia" left-class="hide show-lg">
-    <template #header>
-      <h1>
+  <app-layout class="encyclopedia" left-class="hide show-lg" :menu-absolute="false">
+    <template #main>
+      <h3 v-if="crumbs.length > 0" class="breadcrumbs underlined">
         <template v-for="crumb in crumbs" :key="crumb.url">
           <span class="crumb">
             <router-link :to="crumb.to">{{ crumb.text }}</router-link>
           </span>
         </template>
-      </h1>
-    </template>
-    <template #main>
+      </h3>
       <router-view />
     </template>
     <template v-if="showAside" #left>
@@ -29,7 +27,7 @@ import { useRoute } from 'vue-router'
 import { elementNameList, conceptNameList, getEntry } from './loadData'
 
 const rootCrumb = {
-  text: 'encyclopedia',
+  text: 'Encyclopedia',
   to: '/info',
 }
 
@@ -60,14 +58,16 @@ export default defineComponent({
     })
 
     const crumbs = computed(() => {
-      const crumbs = [rootCrumb]
       if (entry.value != null) {
-        crumbs.push({
-          text: entry.value.title,
-          to: `/info/${entryId.value}`,
-        })
+        return [
+          rootCrumb,
+          {
+            text: entry.value.title,
+            to: `/info/${entryId.value}`,
+          },
+        ]
       }
-      return crumbs
+      return [rootCrumb]
     })
 
     return {
@@ -84,26 +84,23 @@ export default defineComponent({
 .encyclopedia {
   background: #2e006a;
 
-  ::v-deep img {
+  &::v-deep img {
     max-width: 100%;
   }
 }
 
-h1 {
-  padding-top: 30px;
-  font-size: 1.5rem;
-  font-weight: bold;
-  text-transform: uppercase;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.7);
-  text-align: center;
-  display: block;
+.breadcrumbs {
+  margin-top: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  padding-bottom: 5px;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: normal;
 }
 
 // eslint-disable-next-line vue-scoped-css/no-unused-selector
-.crumb > a {
+.crumb:last-child > a {
   color: white;
-  text-transform: uppercase;
 }
 
 // eslint-disable-next-line vue-scoped-css/no-unused-selector

--- a/src/components/EncyclopediaPage/loadData.ts
+++ b/src/components/EncyclopediaPage/loadData.ts
@@ -9,9 +9,9 @@ export const conceptNameList = Object.keys(concepts)
 // used by Encyclopedia Article
 export function getEntry(name: string): IEntry {
   let entry
-  if (elementNameList.includes(name)) {
+  if (Object.hasOwnProperty.call(elements, name)) {
     entry = elements[name as keyof typeof elements]
-  } else if (conceptNameList.includes(name)) {
+  } else if (Object.hasOwnProperty.call(concepts, name)) {
     entry = concepts[name as keyof typeof concepts]
   } else {
     throw new Error(`Encyclopedia Entry not found: ${name}`)

--- a/src/components/GamePage/index.vue
+++ b/src/components/GamePage/index.vue
@@ -145,7 +145,6 @@ export default defineComponent({
     const game = storeNamespace('game')
     const writeCurrentLevelId = game.useMutation('SET_CURRENT_LEVEL_ID')
 
-    // const activeCell = game.useState('activeCell') // this need to me removed ASASP - the same fate as... fate
     const route = useRoute()
     const routeLevelId = computed(() => {
       const rawId = route.params.id as string | undefined

--- a/src/store/gameModule.ts
+++ b/src/store/gameModule.ts
@@ -2,17 +2,15 @@ import { storeModule } from './storeInterfaces'
 
 interface GameState {
   currentLevelID: number | null // check
+  appMenuOpened: boolean
   errors: string[]
 }
 
 export default storeModule({
   namespaced: true,
   state: {
-    activeCell: null,
-    cellSelected: false,
-    hoveredParticles: [],
-    simulationState: false,
     currentLevelID: null,
+    appMenuOpened: false,
     errors: [],
   } as GameState,
   mutations: {
@@ -26,6 +24,9 @@ export default storeModule({
     },
     RESET_ERRORS(state) {
       state.errors = []
+    },
+    SET_MENU_OPENED(state, opened: boolean) {
+      state.appMenuOpened = opened
     },
   },
 })


### PR DESCRIPTION
- all of the content is now left-aligned
- menu button sticks to the main content width
- leaner breadcrumbs
- less horizontal division lines, making the look less busy
- concepts on main encyclopedia page are now split in columns
- when app menu is opened, scroll of the underlying content is prevented

![image](https://user-images.githubusercontent.com/919491/95773593-0fe6c180-0cbf-11eb-9ae1-7ab3075cc290.png)
![image](https://user-images.githubusercontent.com/919491/95773572-03faff80-0cbf-11eb-9029-2535aa1ac520.png)
