### PR TITLE
split huge firebase dependency into it's own lazy-loaded chunk

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -22,6 +22,5 @@ auth.onAuthStateChanged((user) => {
     store.dispatch('userModule/FETCH_USER', user)
   }
 })
-export { db, auth }
 
-export default firebase
+export { db, auth, firebase }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import { createApp } from 'vue'
 import router from './router'
 import { store } from './store/store'
 import './registerServiceWorker'
-import '@/config/firebase'
 import { i18n } from './i18n'
 import App from './App.vue'
 

--- a/src/store/storeInterfaces.ts
+++ b/src/store/storeInterfaces.ts
@@ -1,16 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */ // required due to linting errors for `infer T`
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {
-  StoreOptions,
-  GetterTree,
-  ActionTree,
-  Store,
-  ActionContext,
-  MutationTree,
-  ActionHandler,
-} from 'vuex'
-import firebase from '@/config/firebase'
+import { StoreOptions, GetterTree, ActionTree, ActionHandler } from 'vuex'
+import type { firebase } from '@/config/firebase'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IRootState {}


### PR DESCRIPTION
Firebase size alone is larger (~140KiB) than all of the other vendors together (~120KiB). Splitting it into it's own bundle allows for loading it dynamically only after login requests are made (which currently doesn't work anyway). This should significantly improve initial load and script execution time.