### PR TITLE
fix setting "already won" flag for next level on overlay click

### DIFF
--- a/src/components/AppOverlay.vue
+++ b/src/components/AppOverlay.vue
@@ -1,10 +1,8 @@
 <template>
   <transition :name="state">
-    <div v-if="victory" :class="`wrapper ${state}`">
-      <div class="victory-circle">
-        <h2>
-          You won!
-        </h2>
+    <div v-if="victory" :class="`wrapper ${state}`" @click="$emit('bg-click')">
+      <div class="victory-circle" @click.stop>
+        <h2>You won!</h2>
         <slot></slot>
       </div>
     </div>
@@ -42,6 +40,9 @@ const confettiConfig = {
 export default defineComponent({
   props: {
     state: { type: String, required: false },
+  },
+  emits: {
+    'bg-click': null,
   },
   setup(props) {
     const confetti = new Confetti()

--- a/src/components/GamePage/index.vue
+++ b/src/components/GamePage/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="game">
     <!-- OVERLAY -->
-    <app-overlay :state="overlayGameState" class="overlay" @click="continueAfterWin">
-      <p class="backButton">GO BACK</p>
+    <app-overlay :state="overlayGameState" class="overlay" @bg-click="continueAfterWin">
+      <p class="backButton" tabindex="0" @click="continueAfterWin">GO BACK</p>
       <router-link :to="nextLevelOrOvelay">
         <app-button :overlay="true" :inline="false">NEXT LEVEL</app-button>
       </router-link>


### PR DESCRIPTION
When you click "next level" after winning, the overlay still triggered "continue" logic and set the "already won" flag, preventing the next level win overlay from ever showing. This fixes it by preventing click event propagation.