### PR TITLE
Background dimming feature flag and visual adjustments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,30 +49,24 @@ body {
   color: white;
   padding: 0;
   min-height: 100vh;
-  background: #2e006a; /* Old browsers */
-  //TO DO - change first two gradients
-  background: -moz-linear-gradient(
-    right,
-    #210235 16%,
-    #2e006a 30%,
-    #2e006a 70%,
-    #210235 84%
-  ); /* FF3.6-15 */
-  background: -webkit-linear-gradient(
-    to right,
-    #210235 16%,
-    #2e006a 30%,
-    #2e006a 70%,
-    #210235 84%
-  ); /* Chrome10-25,Safari5.1-6 */
-  background: linear-gradient(
-    to right,
-    #210235 16%,
-    #2e006a 30%,
-    #2e006a 70%,
-    #210235 84%
-  ); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5000a0', endColorstr='#3c1156',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
+  background: linear-gradient(to right, #210235 16%, #2e006a 30%, #2e006a 70%, #210235 84%);
+  position: relative;
+}
+
+#app:before {
+  content: '';
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: black;
+  opacity: 0;
+  will-change: opacity;
+  transition: opacity 0.5s ease-in-out;
+}
+
+body.flag-dimBackground.mode-experiment #app:before {
+  opacity: 0.5;
 }
 
 #nav {

--- a/src/components/Board/BoardLasers.vue
+++ b/src/components/Board/BoardLasers.vue
@@ -74,6 +74,6 @@ $red: #ff0055;
   transition: opacity 0.5s ease-out;
   animation: none;
   stroke-dasharray: initial;
-  stroke-width: 20;
+  stroke-width: 10;
 }
 </style>

--- a/src/components/Board/index.vue
+++ b/src/components/Board/index.vue
@@ -22,8 +22,7 @@
           v-for="(particle, index) in particles"
           :key="index"
           :particle="particle"
-          :displayMagnetic="false"
-          :displayElectric="true"
+          :totalParticles="particles.length"
           :displayGaussian="true"
           @mouseenter="handleMouseEnter(particle.coord)"
         />
@@ -275,10 +274,7 @@ export default defineComponent({
   }
 }
 .grid {
-  transform-origin: 0 0%;
-  @include media('<large') {
-    transform-origin: 0 0;
-  }
+  will-change: transform;
 }
 
 .empty {

--- a/src/components/GamePage/index.vue
+++ b/src/components/GamePage/index.vue
@@ -121,7 +121,7 @@ import AppOverlay from '@/components/AppOverlay.vue'
 import '@/store/store'
 import { useRoute } from 'vue-router'
 import { computed, defineComponent, ref, watch } from 'vue'
-import { useWindowEvent, usePerRouteFlag, useMouseCoords } from '@/mixins'
+import { useWindowEvent, usePerRouteFlag, useMouseCoords, useBodyClass } from '@/mixins'
 import {
   GameOutcome,
   gameController,
@@ -231,6 +231,14 @@ export default defineComponent({
           .finally(() => (rewindingWave.value = false))
       }
     }
+
+    useBodyClass(() => {
+      return {
+        'mode-laser': visType.value === SimulationVisType.Laser,
+        'mode-wave': visType.value === SimulationVisType.QuantumWave,
+        'mode-experiment': visType.value === SimulationVisType.Experiment,
+      }
+    })
 
     const laserOpacity = computed(() => {
       switch (visType.value) {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -12,6 +12,8 @@ const params = new URL(window.location.href).searchParams
 export const $flags = Object.freeze({
   /** display absorption "progress" as circular */
   circleAbsorptions: getBoolFlag('ca'),
+  /** dim background when experiment mode is active */
+  dimBackground: getBoolFlag('dim'),
 })
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -29,5 +31,10 @@ function getStrFlag(name: string): string | null {
 export const flagsPlugin: Plugin = {
   install: (app) => {
     app.config.globalProperties.$flags = $flags
+    for (const f in $flags) {
+      if ($flags[f as keyof typeof $flags]) {
+        document.body.classList.add(`flag-${f}`)
+      }
+    }
   },
 }

--- a/src/mixins/util.ts
+++ b/src/mixins/util.ts
@@ -1,4 +1,14 @@
-import { proxyRefs, readonly, ref, unref, watchEffect } from 'vue'
+import {
+  proxyRefs,
+  readonly,
+  Ref,
+  ref,
+  shallowRef,
+  unref,
+  watch,
+  watchEffect,
+  WatchStopHandle,
+} from 'vue'
 import { useRouter } from 'vue-router'
 
 /**
@@ -30,5 +40,52 @@ export function usePerRouteFlag(): { flag: boolean; set(): void } {
     set: () => {
       flag.value = true
     },
+  })
+}
+
+/**
+ * A computed ref that only notifies it's deps when the computed value actually changed.
+ * @param getter the function that returns computed value
+ * @param compare comparison function. When not passed, a strong comparison (`===`) operator is used.
+ */
+export function memoized<T>(getter: () => T, compare?: (a: T, b: T) => boolean): Ref<T> {
+  const val = shallowRef()
+  watch(
+    getter,
+    (valA, valB) => {
+      if (valB === undefined || !(compare != null ? compare(valA, valB) : valA === valB)) {
+        val.value = valA
+      }
+    },
+    { immediate: true }
+  )
+  return val
+}
+
+const bodyClasses: Record<string, number> = {}
+/**
+ * Compute classes to apply to a body tag.
+ * @param src classes getter
+ */
+export function useBodyClass(src: () => Record<string, boolean>): WatchStopHandle {
+  return watch(src, (classes, _, onInvalidate) => {
+    for (const c in classes) {
+      if (classes[c]) {
+        bodyClasses[c] = (bodyClasses[c] ?? 0) + 1
+        if (bodyClasses[c] > 0) {
+          document.body.classList.add(c)
+        }
+      }
+    }
+    onInvalidate(() => {
+      for (const c in classes) {
+        if (classes[c]) {
+          bodyClasses[c] = bodyClasses[c] - 1
+          if (bodyClasses[c] <= 0) {
+            document.body.classList.remove(c)
+          }
+        }
+      }
+    })
   })
 }


### PR DESCRIPTION
- background darkens when experiment is running (under a `dim` feature flag)
	- I personally think this is a bad change, but let's evaluate it properly and see what everyone thinks about it
- some style changes for experiment laser width and absorption percentage (see screenshot below)
- reduced the fidelty (path color and width variance) of photon rendering when there are many photon instances on the screen
	- The fidelty decrease is hard to notice, as those photons are almost transparent anyway, and it cuts down the number of DOM nodes to update significantly. This is still very slow, but way better than it was before. Next optimization step will probably require direct canvas rendering.

How the experiments looks with flags `?dim&ca`:
![image](https://user-images.githubusercontent.com/919491/96712311-38e21300-139f-11eb-9ba8-bd1513bada5d.png)
