### PR TITLE
Visual changes

### DIFF
--- a/src/components/AppMenu.vue
+++ b/src/components/AppMenu.vue
@@ -10,7 +10,6 @@
         <router-link v-if="isLoggedIn" to="/myaccount">MY ACCOUNT</router-link>
         <router-link v-else to="/login">LOG IN</router-link>
         <router-link to="/lab">VIRTUAL LAB</router-link>
-        <router-link to="/levels">LEVELS</router-link>
         <router-link to="/info">ENCYCLOPEDIA</router-link>
         <router-link to="/options">OPTIONS</router-link>
         <a href="https://medium.com/quantum-photons" target="_blank">BLOG</a>

--- a/src/components/AppMenuButton.vue
+++ b/src/components/AppMenuButton.vue
@@ -125,7 +125,7 @@ export default defineComponent({
 
 // eslint-disable-next-line vue-scoped-css/no-unused-selector
 .nav-icon.router-link-active {
-  color: $fuchsia;
+  color: white;
 }
 
 .alt > .nav-icon {
@@ -148,7 +148,7 @@ export default defineComponent({
 // eslint-disable-next-line vue-scoped-css/no-unused-selector
 .alt > .nav-icon.router-link-active > span {
   color: $purple-dark;
-  background: $fuchsia;
+  background: $grey;
 }
 
 .menu-icon {

--- a/src/components/AppMenuButton.vue
+++ b/src/components/AppMenuButton.vue
@@ -23,7 +23,7 @@
         <div><IconLevels /></div>
         <span>LEVELS</span>
       </router-link>
-      <router-link to="/sandbox" class="nav-icon">
+      <router-link to="/lab" class="nav-icon">
         <div><IconLab /></div>
         <span>LAB</span>
       </router-link>
@@ -163,7 +163,7 @@ export default defineComponent({
   .bar2,
   .bar3 {
     width: 35px;
-    height: 3px;
+    height: 1px;
     background-color: rgb(255, 255, 255);
     margin: 8px 0;
     transition: transform 0.3s, opacity 0.3s;

--- a/src/components/Board/ActionHint.vue
+++ b/src/components/Board/ActionHint.vue
@@ -60,10 +60,10 @@ export default defineComponent({
   transform-origin: 32px 32px;
   opacity: 0;
   &::v-deep([fill]) {
-    fill: white;
+    fill: $fuchsia;
   }
   &::v-deep([stroke]) {
-    stroke: white;
+    stroke: $fuchsia;
   }
 }
 
@@ -88,10 +88,10 @@ export default defineComponent({
     transform: rotate(3deg);
   }
   8% {
-    transform: rotate(-6deg);
+    transform: rotate(-10deg);
   }
   10% {
-    transform: rotate(6deg);
+    transform: rotate(10deg);
   }
   12% {
     transform: rotate(-4deg);
@@ -136,11 +136,12 @@ export default defineComponent({
     opacity: 0;
   }
   40% {
-    opacity: 0.8;
+    opacity: 0.2;
   }
 
   80% {
     opacity: 0;
+    transform: scale(1.8, 1.8);
   }
 }
 </style>

--- a/src/components/EncyclopediaPage/EncyclopediaLinkList.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaLinkList.vue
@@ -55,12 +55,14 @@ export default defineComponent({
     margin-top: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
     padding-bottom: 5px;
+    margin-bottom: 10px;
+    text-transform: uppercase;
   }
 }
 
 .entries {
   columns: 330px;
-  column-rule: 1px solid rgba(255, 255, 255, 0.3);
+  column-rule: 1px solid rgba(255, 255, 255, 0.0);
   > .link {
     display: block;
   }

--- a/src/components/EncyclopediaPage/EncyclopediaMainPage.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMainPage.vue
@@ -85,6 +85,7 @@ export default defineComponent({
 
 h2 {
   padding-bottom: 5px;
+  text-transform: uppercase;
 }
 
 .underline {

--- a/src/components/GamePage/GameInfobox.vue
+++ b/src/components/GamePage/GameInfobox.vue
@@ -109,8 +109,8 @@ export default defineComponent({
 }
 
 .link {
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.3);
   font-weight: 500;
-  text-decoration: none;
+  text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
relatively small visual changes here and there.
Few more things that should be changed (cc @Frizi ):
- level titles should be centered above the board
- let's have the icons only in the menu (altmenu right now)
- let's use the circle progress bars next to detectors